### PR TITLE
[CI] Add travis and pip auto build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: python
+python: ["2.7"]
+
+install:
+  - pip install -r requirements-dev.txt
+
+script: python test.py
+
+# RTFM: https://docs.travis-ci.com/user/deployment/pypi/
+# deploy:
+#   provider: pypi
+#   user: "Your username"
+#   password: "Your password"
+#   on:
+#     tags: true


### PR DESCRIPTION
Python tests work, `.travis.yml` has some comments regarding PIP deployment

Other python versions should be supported? For now it's only 2.7